### PR TITLE
unpad  add the format valid

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -22,6 +22,11 @@ func Unpad(padded []byte, size int) ([]byte, error) {
 
 	lastPad := padded[paddedLen-1]
 	padLen := int(lastPad)
+
+	if padLen > size {
+		return nil, errors.New("pkcs7: Padded value larger than size.")
+	}
+
 	for i := paddedLen - padLen; i < paddedLen; i++ {
 		if padded[i] != lastPad {
 			return nil, errors.New("pkcs7: Padded value wasn't in correct format.")

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -14,11 +14,21 @@ func Pad(buf []byte, size int) ([]byte, error) {
 }
 
 func Unpad(padded []byte, size int) ([]byte, error) {
-	if len(padded)%size != 0 {
+	paddedLen := len(padded)
+
+	if paddedLen%size != 0 {
 		return nil, errors.New("pkcs7: Padded value wasn't in correct size.")
 	}
 
-	bufLen := len(padded) - int(padded[len(padded)-1])
+	lastPad := padded[paddedLen-1]
+	padLen := int(lastPad)
+	for i := paddedLen - padLen; i < paddedLen; i++ {
+		if padded[i] != lastPad {
+			return nil, errors.New("pkcs7: Padded value wasn't in correct format.")
+		}
+	}
+
+	bufLen := paddedLen - padLen
 	buf := make([]byte, bufLen)
 	copy(buf, padded[:bufLen])
 	return buf, nil

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -26,6 +26,14 @@ func TestPkcs7(t *testing.T) {
 		}
 	})
 
+	t.Run("Unpads error format", func(t *testing.T) {
+		_, err := Unpad([]byte("12345678901\x06\x06\x06\x06\x06"), BLOCK_SIZE)
+		if err == nil {
+			panic(fmt.Sprint("process error"))
+		}
+
+	})
+
 	t.Run("Handles long", func(t *testing.T) {
 		longStr := []byte("123456789012345678901234567890123456789012345678901234567890")
 		padded, _ := Pad(longStr, BLOCK_SIZE)

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -26,6 +26,14 @@ func TestPkcs7(t *testing.T) {
 		}
 	})
 
+	t.Run("Unpads error length", func(t *testing.T) {
+		_, err := Unpad([]byte("123456789012345678901234567890123456789012345678901234567890\x11\x11\x11\x11"), BLOCK_SIZE)
+		if err == nil {
+			panic(fmt.Sprint("process error"))
+		}
+
+	})
+
 	t.Run("Unpads error format", func(t *testing.T) {
 		_, err := Unpad([]byte("12345678901\x06\x06\x06\x06\x06"), BLOCK_SIZE)
 		if err == nil {


### PR DESCRIPTION
func unpad 
when the slice of input is not  correct formated , it will throw a panic